### PR TITLE
fix(web-ui): 修复重新创建容器后历史记录丢失问题

### DIFF
--- a/web_ui.py
+++ b/web_ui.py
@@ -4,10 +4,12 @@
 import threading
 import time
 import datetime
+import os
+import json
 from flask import Flask, render_template, request, jsonify
 from flask_socketio import SocketIO, emit
 from croniter import croniter
-from traffic_consumer import TrafficConsumer
+from traffic_consumer import TrafficConsumer, STATS_FILE
 
 # 初始化 Flask 和 SocketIO
 app = Flask(__name__)
@@ -20,6 +22,35 @@ consumer_thread = None
 status_thread = None
 status_thread_stop = threading.Event()
 log_enabled = False
+
+def load_history_from_stats():
+    """从stats.json加载历史运行记录"""
+    if not os.path.exists(STATS_FILE):
+        return []
+
+    try:
+        with open(STATS_FILE, 'r', encoding='utf-8') as f:
+            stats_data = json.load(f)
+
+        # 创建一个临时实例用于格式化字节数
+        temp_consumer = TrafficConsumer()
+
+        # 将stats.json中的每次运行转换为历史记录格式
+        history = []
+        for run_id, stats in sorted(stats_data.items(), key=lambda x: x[0], reverse=True):
+            record = {
+                "timestamp": stats.get('end_time') or stats.get('start_time'),
+                "result": "成功",  # 保存到stats的都是完成的任务
+                "bytes_consumed": temp_consumer.format_bytes(stats.get('total_bytes', 0)),
+                "download_count": stats.get('download_count', 0)
+            }
+            history.append(record)
+
+        # 限制历史记录数量
+        return history[:50]
+    except Exception as e:
+        print(f"加载历史记录失败: {e}")
+        return []
 
 def status_emitter():
     """定期向前端发送状态更新"""
@@ -63,6 +94,7 @@ def status_emitter():
                 'running': False,
                 'thread_status': {},
                 'thread_count': consumer_instance.threads if consumer_instance else 0,
+                'config': consumer_instance.config_name if consumer_instance else None,
                 'url_usage_stats': []
             })
         socketio.sleep(1)
@@ -81,15 +113,38 @@ def scheduler_status_emitter():
                         job_details = f"Cron: {consumer_instance.cron_expr}"
                     elif consumer_instance.interval:
                         job_details = f"Interval: {consumer_instance.interval} minutes"
-            
+
+            # 合并当前实例的历史记录和stats.json中的历史记录
+            current_history = consumer_instance.history if consumer_instance.history else []
+            stored_history = load_history_from_stats()
+
+            # 去重并合并（优先使用当前实例的记录）
+            all_history = current_history + stored_history
+            # 改进去重：将时间戳统一转换为秒级进行比较
+            seen_timestamps = set()
+            unique_history = []
+            for record in all_history:
+                ts = record.get('timestamp')
+                # 将时间戳标准化到秒级（去掉毫秒和T）
+                normalized_ts = ts.replace('T', ' ').split('.')[0] if ts else None
+                if normalized_ts not in seen_timestamps:
+                    seen_timestamps.add(normalized_ts)
+                    unique_history.append(record)
+
             status = {
                 'next_run_time': next_run_time,
                 'job_details': job_details,
-                'history': consumer_instance.history
+                'history': unique_history[:50]  # 限制50条
             }
             socketio.emit('scheduler_status_update', status)
         else:
-            socketio.emit('scheduler_status_update', {'next_run_time': None, 'job_details': None, 'history': []})
+            # 即使没有运行实例，也从stats.json加载历史记录
+            stored_history = load_history_from_stats()
+            socketio.emit('scheduler_status_update', {
+                'next_run_time': None,
+                'job_details': None,
+                'history': stored_history
+            })
         socketio.sleep(2) # 调度器状态不需要太频繁更新
 
 @app.route('/')


### PR DESCRIPTION
## 问题描述
  重新创建 Docker 容器后，虽然 `stats.json` 文件中保存了历史运行记录，但 Web UI 的执行历史表格显示为空。

  ## 原因分析
  - `scheduler_status_emitter()` 只发送当前运行实例的动态历史记录 (`consumer_instance.history`)
  - 容器重启后，如果没有新的运行任务，`consumer_instance.history` 为空
  - 已保存在 `stats.json` 中的历史数据无法被加载和显示

  ## 修复方案
  1. 新增 `load_history_from_stats()` 函数，从 `stats.json` 加载历史运行记录，并限制历史记录最多显示 50
  条，避免因历史数据过多导致的占用更多内存和前端数据加载慢的问题
  2. 修改 `scheduler_status_emitter()`：
     - 合并当前实例的运行时记录和 `stats.json` 中的持久化记录
     - 实现去重逻辑，按时间戳去重
     - 即使没有运行实例，也会加载并显示历史记录
  3. 统一历史记录结果列显示为"成功"（之前从 stats.json 加载的显示 "completed"，运行时添加的显示"成功"，不一致）
  4. 修复时间戳格式不一致导致的重复记录问题（运行时记录格式为 ISO 格式带毫秒，stats.json
  中为不带毫秒的字符串格式，导致去重失败）
  5. 修复 `status_emitter()` 在任务未运行时不发送 `config` 字段，导致前端"当前配置"显示被覆盖为"未命名配置"的问题

  ## 测试验证
  - ✅ 重新创建容器后，历史记录表格正确显示所有历史运行数据
  - ✅ 调度任务运行后，新记录会追加到历史列表中
  - ✅ 历史记录结果列统一显示为"成功"
  - ✅ 历史记录无重复显示
  - ✅ 选择配置后，"当前配置"显示正确且不会被覆盖