### PR TITLE
[FIX] Change default threads from 1 to 4

### DIFF
--- a/app/consumer.py
+++ b/app/consumer.py
@@ -40,7 +40,7 @@ class TrafficConsumer:
                  config_name="default", url_strategy="random", logger=None, history_callback=None,
                  invalid_url_callback=None, auto_remove_failed_url=False):
         initial_urls = list(urls) if urls else list(DEFAULT_URLS)
-        self.threads = threads if threads is not None else 1
+        self.threads = threads if threads is not None else 4
         self.limit_speed = limit_speed if limit_speed is not None else 0  # 限速，单位MB/s，0表示不限速
         self.duration = duration  # 持续时间，单位秒
         self.count = count  # 下载次数


### PR DESCRIPTION
webui保存配置时，如果线程数为空，虽然界面提示默认值为4，但保存时实际会按1来保存。改动后修复